### PR TITLE
Fix lack of webpack-dev-server and twitter authorize path

### DIFF
--- a/config/environments/development.example.rb
+++ b/config/environments/development.example.rb
@@ -27,6 +27,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Set environment secrets
+  ENV['ORIGIN'] = 'http://localhost:8080'
+  ENV['OAUTH_CALLBACK'] = 'http://127.0.0.1:3000/access_token'
   ENV['SECRET_KEY_BASE'] = '55ddbe69b5e1cf8ae25011f404fc1a5a74c12433ad24eb1c09721b9ad8697c3362c20161825c90115a08202704bbe4062ea9cc7387cf755094d702c04b941cbb'
   ENV['TWITTER_CONSUMER_KEY'] = ''
   ENV['TWITTER_CONSUMER_SECRET'] = ''

--- a/config/initializers/twitter_oauth.rb
+++ b/config/initializers/twitter_oauth.rb
@@ -1,6 +1,6 @@
 TWITTER = OAuth::Consumer.new(
   Rails.application.secrets.twitter_consumer_key,
   Rails.application.secrets.twitter_consumer_secret,
-  authorize_path: '/oauth/authenticate',
+  authorize_path: '/oauth/authorize',
   site: 'https://api.twitter.com'
 )

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-router": "^0.12.4",
     "reqwest": "^1.1.5",
     "style-loader": "^0.8.3",
-    "webpack": "^1.6.0"
+    "webpack": "^1.6.0",
+    "webpack-dev-server": "^1.14.0"
   }
 }


### PR DESCRIPTION
Hi Fred,

I had read following article.

Fred Guest | Building a Stateless Rails API with React and Twitter OAuth
http://fredguest.com/2015/03/06/building-a-stateless-rails-api-with-react-and-twitter-oauth/


Thank you for your very very useful article and example code !!

When I had cloned the example and activated it, I encountered errors.

So I send pull-request. Please check it out.

* 1. Lack of `webpack-dev-server`
* 2. Twitter Authorize URL is `https://api.twitter.com/oauth/authorize` now, not `https://api.twitter.com/oauth/authenticate`
